### PR TITLE
Changes around the checkout summary view to avoid confusion

### DIFF
--- a/resources/views/livewire/checkout-page.blade.php
+++ b/resources/views/livewire/checkout-page.blade.php
@@ -52,17 +52,19 @@
                             </div>
                         @endif
 
-                        @foreach ($cart->taxBreakdown->amounts as $tax)
-                            <div class="flex flex-wrap py-4">
-                                <dt class="w-1/2 font-medium">
-                                    {{ $tax->description }}
-                                </dt>
+                        @if(config('lunar.pricing.stored_inclusive_of_tax') === false)
+                            @foreach ($cart->taxBreakdown->amounts as $tax)
+                                <div class="flex flex-wrap py-4">
+                                    <dt class="w-1/2 font-medium">
+                                        {{ $tax->description }}
+                                    </dt>
 
-                                <dd class="w-1/2 text-right">
-                                    {{ $tax->price->formatted() }}
-                                </dd>
-                            </div>
-                        @endforeach
+                                    <dd class="w-1/2 text-right">
+                                        {{ $tax->price->formatted() }}
+                                    </dd>
+                                </div>
+                            @endforeach
+                        @endif
 
                         <div class="flex flex-wrap py-4">
                             <dt class="w-1/2 font-medium">


### PR DESCRIPTION
I've surrounded the display of the tax line in the checkout summary to appear only if pricing taxes are not included in the price. 

These changes are here to avoid confusion when the taxes are included inside the price.
