### PR TITLE
changing the wrong attribute type in the attribute seeder data

### DIFF
--- a/database/seeders/data/attributes.json
+++ b/database/seeders/data/attributes.json
@@ -3,7 +3,7 @@
         "name": "Details",
         "handle": "details",
         "type": "Lunar\\FieldTypes\\ListField",
-        "attribute_type": "Lunar\\FieldTypes\\Product",
+        "attribute_type": "Lunar\\Models\\Product",
         "configuration": {}
     }
 ]


### PR DESCRIPTION
This is a minor change to the incorrect attribute_type in attribute.json. Using the seeder, the "Details" field is not displayed in the product.