### PR TITLE
Fixes HTML rendering bug in description

### DIFF
--- a/app/Livewire/ProductPage.php
+++ b/app/Livewire/ProductPage.php
@@ -89,7 +89,7 @@ class ProductPage extends Component
      */
     public function getImagesProperty(): Collection
     {
-        return $this->product->media;
+        return $this->product->media->sortBy('order_column');
     }
 
     /**

--- a/resources/views/components/collection-sale.blade.php
+++ b/resources/views/components/collection-sale.blade.php
@@ -8,7 +8,7 @@
 
                 @if ($this->saleCollection->translateAttribute('description'))
                     <p class="mt-1 text-lg font-medium">
-                        {{ $this->saleCollection->translateAttribute('description') }}
+                        {!! $this->saleCollection->translateAttribute('description') !!}
                     </p>
                 @endif
 

--- a/resources/views/livewire/product-page.blade.php
+++ b/resources/views/livewire/product-page.blade.php
@@ -38,7 +38,7 @@
                 </p>
 
                 <article class="mt-4 text-gray-700">
-                    {{ $this->product->translateAttribute('description') }}
+                    {!! $this->product->translateAttribute('description') !!}
                 </article>
 
                 <form class="mt-4">


### PR DESCRIPTION
Fixes: 
- HTML is rendered as string for the description fields on Product and Collection

Applies:
- Sorting to media on Product page

<img width="464" alt="Screenshot 2024-11-17 at 21 55 51" src="https://github.com/user-attachments/assets/512c7967-5706-4282-aa2d-e7315778e6e4">
<img width="609" alt="Screenshot 2024-11-17 at 21 56 13" src="https://github.com/user-attachments/assets/dbf513d7-55d7-41a9-a63b-6960cad8a9b9">
